### PR TITLE
Changes in support of ZK upgrade in binder/nameservice

### DIFF
--- a/boot/zk_common.sh
+++ b/boot/zk_common.sh
@@ -57,7 +57,7 @@ function zk_common_delegated_dataset
 
     chmod 777 ${ZK_ROOT}
     mkdir -p ${ZK_ROOT}/zookeeper
-    chown zookeeper:zookeeper ${ZK_ROOT}/zookeeper
+    chown -R zookeeper:zookeeper ${ZK_ROOT}/zookeeper
 }
 
 # sets up hourly log rotation

--- a/boot/zk_common.sh
+++ b/boot/zk_common.sh
@@ -56,7 +56,8 @@ function zk_common_delegated_dataset
     fi
 
     chmod 777 ${ZK_ROOT}
-    sudo -u zookeeper mkdir -p ${ZK_ROOT}/zookeeper
+    mkdir -p ${ZK_ROOT}/zookeeper
+    chown zookeeper:zookeeper ${ZK_ROOT}/zookeeper
 }
 
 # sets up hourly log rotation

--- a/smf/manifests/zookeeper.xml.in
+++ b/smf/manifests/zookeeper.xml.in
@@ -27,7 +27,7 @@
       <service_fmri value='svc:/smartdc/applications/config-agent' />
     </dependency>
     <method_context>
-      <method_credential group='hadoop' user='zookeeper'/>
+      <method_credential group='zookeeper' user='zookeeper'/>
     </method_context>
     <exec_method name='start' type='method' exec='/opt/local/sbin/zkServer.sh start' timeout_seconds='60'/>
     <exec_method name='stop' type='method' exec='/opt/local/sbin/zkServer.sh stop' timeout_seconds='60'/>


### PR DESCRIPTION
Changes tracked in [MANTA-3543](https://jira.joyent.us/browse/MANTA-3543)

Binder ZK version is being upgraded to 3.4.12 as an intermediary step to the next major version; hadoop group is no longer in use.

Removed `sudo` dependency in the boot script as well.

Binder [PR](https://github.com/joyent/binder/pull/14)